### PR TITLE
WIP: fix library environment variable for macos builds

### DIFF
--- a/.github/workflows/github-test.yml
+++ b/.github/workflows/github-test.yml
@@ -17,7 +17,7 @@ jobs:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         build_type: [Release]
         config_zip: [ {header_only: OFF, python_bindings: ON}, {header_only: ON, python_bindings: OFF} ]
         tardigrade_opt: [OFF, ON]

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -19,17 +19,12 @@ add_custom_command(TARGET ${PYTHON_TARGET} PRE_BUILD
                   )
 # Add pytests as a ctest function for automated testing under unified CMake/CTest tools
 if(${APPLE})
-    add_test(
-        NAME pytest
-        COMMAND
-            ${CMAKE_COMMAND} -E env DYLD_FALLBACK_LIBRARY_PATH=${CMAKE_BINARY_DIR}/${CPP_SRC_PATH} pytest
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PYTHON_SRC_PATH}
-    )
+    set(LIBRARY_MODIFICATION "DYLD_FALLBACK_LIBRARY_PATH=${CMAKE_BINARY_DIR}/${CPP_SRC_PATH}")
 else()
-    add_test(
-        NAME pytest
-        COMMAND
-            ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/${CPP_SRC_PATH} pytest
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PYTHON_SRC_PATH}
-    )
+    set(LIBRARY_MODIFICATION "LD_LIBRARY_PATH=ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/${CPP_SRC_PATH}")
 endif()
+add_test(
+    NAME pytest
+    COMMAND ${CMAKE_COMMAND} -E env ${LIBRARY_MODIFICATION} pytest
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PYTHON_SRC_PATH}
+)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -18,9 +18,18 @@ add_custom_command(TARGET ${PYTHON_TARGET} PRE_BUILD
                    COMMENT "Building the ${PROJECT_NAME} Cython extension - python target"
                   )
 # Add pytests as a ctest function for automated testing under unified CMake/CTest tools
-add_test(NAME pytest
-         COMMAND
-             ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/${CPP_SRC_PATH}
-             pytest
-         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PYTHON_SRC_PATH}
-        )
+if(${APPLE})
+    add_test(
+        NAME pytest
+        COMMAND
+            ${CMAKE_COMMAND} -E env DYLD_FALLBACK_LIBRARY_PATH=${CMAKE_BINARY_DIR}/${CPP_SRC_PATH} pytest
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PYTHON_SRC_PATH}
+    )
+else()
+    add_test(
+        NAME pytest
+        COMMAND
+            ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/${CPP_SRC_PATH} pytest
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PYTHON_SRC_PATH}
+    )
+endif()


### PR DESCRIPTION
Fix the macOS as-built python package test command. Enable the GitHub PR tests on macOS.