### PR TITLE
TST: add linux/macos conda-build test

### DIFF
--- a/.github/workflows/conda-recipe-test.yml
+++ b/.github/workflows/conda-recipe-test.yml
@@ -1,0 +1,51 @@
+name: Test conda-recipe on pull request
+run-name: ${{ github.actor }} is testing the conda-recipe on a pull request
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+    branches:
+      - dev
+      - main
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+      - name: MiniConda setup
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+            miniforge-variant: Miniforge3
+            channels: conda-forge
+            channel-priority: true
+            auto-activate-base: false
+            activate-environment: "test-environment"
+      - name: check solution
+        run: |
+          conda env export
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+            echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+            echo "environment-file=${{ github.workspace }}/environment.txt" >> "$GITHUB_OUTPUT"
+            echo "moose-dir=${{ github.workspace }}/moose-dir" >> "$GITHUB_OUTPUT"
+      - name: Conda environment
+        shell: bash -el {0}
+        run: |
+            conda install --file ${{ steps.strings.outputs.environment-file }} --yes --channel conda-forge
+      - name: Conda-Build
+        shell: bash -el {0}
+        run: |
+            VERSION=$(python -m setuptools_scm) conda mambabuild recipe --channel conda-forge --no-anaconda-upload

--- a/.github/workflows/conda-recipe-test.yml
+++ b/.github/workflows/conda-recipe-test.yml
@@ -32,18 +32,14 @@ jobs:
             auto-activate-base: false
             activate-environment: "test-environment"
       - name: check solution
-        run: |
-          conda env export
+        run: conda env export
       - name: Set reusable strings
         id: strings
         shell: bash
-        run: |
-            echo "environment-file=${{ github.workspace }}/conda-build.txt" >> "$GITHUB_OUTPUT"
+        run: echo "environment-file=${{ github.workspace }}/conda-build.txt" >> "$GITHUB_OUTPUT"
       - name: Conda environment
         shell: bash -el {0}
-        run: |
-            conda install --file ${{ steps.strings.outputs.environment-file }} --yes --channel conda-forge
+        run: conda install --file ${{ steps.strings.outputs.environment-file }} --yes --channel conda-forge
       - name: Conda-Build
         shell: bash -el {0}
-        run: |
-            VERSION=$(python -m setuptools_scm) conda mambabuild recipe --channel conda-forge --no-anaconda-upload
+        run: VERSION=$(python -m setuptools_scm) conda mambabuild recipe --channel conda-forge --no-anaconda-upload

--- a/.github/workflows/conda-recipe-test.yml
+++ b/.github/workflows/conda-recipe-test.yml
@@ -40,4 +40,4 @@ jobs:
         run: conda install --file ${{ steps.strings.outputs.environment-file }} --yes --channel conda-forge
       - name: Conda-Build
         shell: bash -el {0}
-        run: VERSION=$(python -m setuptools_scm) conda mambabuild recipe --channel conda-forge --no-anaconda-upload
+        run: conda mambabuild recipe --channel conda-forge --no-anaconda-upload

--- a/.github/workflows/conda-recipe-test.yml
+++ b/.github/workflows/conda-recipe-test.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
             echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-            echo "environment-file=${{ github.workspace }}/environment.txt" >> "$GITHUB_OUTPUT"
+            echo "environment-file=${{ github.workspace }}/conda-build.txt" >> "$GITHUB_OUTPUT"
             echo "moose-dir=${{ github.workspace }}/moose-dir" >> "$GITHUB_OUTPUT"
       - name: Conda environment
         shell: bash -el {0}

--- a/.github/workflows/conda-recipe-test.yml
+++ b/.github/workflows/conda-recipe-test.yml
@@ -38,9 +38,7 @@ jobs:
         id: strings
         shell: bash
         run: |
-            echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
             echo "environment-file=${{ github.workspace }}/conda-build.txt" >> "$GITHUB_OUTPUT"
-            echo "moose-dir=${{ github.workspace }}/moose-dir" >> "$GITHUB_OUTPUT"
       - name: Conda environment
         shell: bash -el {0}
         run: |

--- a/.github/workflows/conda-recipe-test.yml
+++ b/.github/workflows/conda-recipe-test.yml
@@ -31,8 +31,6 @@ jobs:
             channel-priority: true
             auto-activate-base: false
             activate-environment: "test-environment"
-      - name: check solution
-        run: conda env export
       - name: Set reusable strings
         id: strings
         shell: bash

--- a/.github/workflows/github-test.yml
+++ b/.github/workflows/github-test.yml
@@ -41,9 +41,7 @@ jobs:
         id: strings
         shell: bash
         run: |
-            echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
             echo "environment-file=${{ github.workspace }}/environment.txt" >> "$GITHUB_OUTPUT"
-            echo "moose-dir=${{ github.workspace }}/moose-dir" >> "$GITHUB_OUTPUT"
       - name: Conda environment
         shell: bash -el {0}
         run: |
@@ -55,7 +53,6 @@ jobs:
           cmake --build build --target all
       - name: Test
         shell: bash -el {0}
-#        working-directory: ${{ steps.strings.outputs.build-output-dir }}
         run: |
           conda activate test-environment
           ctest --test-dir build -V

--- a/.github/workflows/github-test.yml
+++ b/.github/workflows/github-test.yml
@@ -34,8 +34,6 @@ jobs:
             channel-priority: true
             auto-activate-base: false
             activate-environment: "test-environment"
-      - name: check solution
-        run: conda env export
       - name: Set reusable strings
         id: strings
         shell: bash

--- a/.github/workflows/github-test.yml
+++ b/.github/workflows/github-test.yml
@@ -35,24 +35,17 @@ jobs:
             auto-activate-base: false
             activate-environment: "test-environment"
       - name: check solution
-        run: |
-          conda env export
+        run: conda env export
       - name: Set reusable strings
         id: strings
         shell: bash
-        run: |
-            echo "environment-file=${{ github.workspace }}/environment.txt" >> "$GITHUB_OUTPUT"
+        run: echo "environment-file=${{ github.workspace }}/environment.txt" >> "$GITHUB_OUTPUT"
       - name: Conda environment
         shell: bash -el {0}
-        run: |
-            conda install --file ${{ steps.strings.outputs.environment-file }} --yes --channel conda-forge
+        run: conda install --file ${{ steps.strings.outputs.environment-file }} --yes --channel conda-forge
       - name: Build
         shell: bash -el {0}
-        run: |
-          cmake -S . -B build -DTARDIGRADE_ERROR_TOOLS_BUILD_PYTHON_BINDINGS=${{ matrix.config_zip.python_bindings }} -DTARDIGRADE_HEADER_ONLY=${{ matrix.config_zip.header_only }} -DTARDIGRADE_ERROR_TOOLS_OPT=${{ matrix.tardigrade_opt }}
-          cmake --build build --target all
+        run: cmake -S . -B build -DTARDIGRADE_ERROR_TOOLS_BUILD_PYTHON_BINDINGS=${{ matrix.config_zip.python_bindings }} -DTARDIGRADE_HEADER_ONLY=${{ matrix.config_zip.header_only }} -DTARDIGRADE_ERROR_TOOLS_OPT=${{ matrix.tardigrade_opt }} && cmake --build build --target all
       - name: Test
         shell: bash -el {0}
-        run: |
-          conda activate test-environment
-          ctest --test-dir build -V
+        run: conda activate test-environment && ctest --test-dir build -V

--- a/conda-build.txt
+++ b/conda-build.txt
@@ -1,0 +1,4 @@
+boa
+python
+setuptools >=77
+setuptools_scm >=8

--- a/environment.txt
+++ b/environment.txt
@@ -13,7 +13,8 @@ pytest-cov
 pytest-xdist
 python
 python-build
-setuptools_scm>=6.2
+setuptools >=77
+setuptools_scm >=8
 sphinx>=3.0.4
 sphinx_rtd_theme>=0.4.3
 sphinxcontrib-bibtex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=62", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
 {% set name = "tardigrade_error_tools" %}
+{% set version = "0.0.0" %}
 
 package:
   name: {{ name|lower }}
-  version: {{ VERSION }}
+  version: {{ version }}
 
 source:
   path: '..'
@@ -10,11 +11,11 @@ source:
 build:
   number: 0
   script_env:
-    - SETUPTOOLS_SCM_PRETEND_VERSION={{ VERSION }}
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script:
     - set -x
     # Build and install c++ libraries
-    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib
+    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib
     - cmake --build build --target tardigrade_error_tools tardigrade_error_tools_PYTHON
     - cmake --install build --prefix ${PREFIX}
     # Build and install Conda package

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,8 @@ requirements:
     - python-build
     - pip
     - cython
-    - setuptools >=62
-    - setuptools_scm >=6.2
+    - setuptools >=77
+    - setuptools_scm >=8
     - eigen >=3.3.7
     - libboost-python-devel >=1.82
     - doxygen

--- a/src/python/pyproject.toml.in
+++ b/src/python/pyproject.toml.in
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=6.2", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Adds per-PR tests for the conda-recipe on ubuntu and macos